### PR TITLE
Add some optional parameters for customizing window appearance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.geany
+.project
+.cproject

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,12 @@ cmake_minimum_required(VERSION 2.8.3)
 project(keyboard)
 
 find_package(catkin REQUIRED COMPONENTS roscpp std_msgs message_generation)
-find_package(SDL REQUIRED)
-set(LIBS ${SDL_LIBRARY})
+
+INCLUDE(FindPkgConfig)
+PKG_SEARCH_MODULE(SDL2 REQUIRED SDL2)
+PKG_SEARCH_MODULE(SDL2TTF REQUIRED SDL2_ttf)
+set(SDL2_LIBRARIES ${SDL2_LIBRARY} ${SDL2TTF_LIBRARIES})
+set(SDL2_INCLUDE_DIRS ${SDL2_INCLUDE_DIRS} ${SDL2TTF_INCLUDE_DIRS})
 
 #######################################
 ## Declare ROS messages and services ##
@@ -24,22 +28,20 @@ generate_messages(
 ###################################
 
 catkin_package(
-  #INCLUDE_DIRS include
-#  LIBRARIES keyboard
   CATKIN_DEPENDS roscpp std_msgs message_runtime
-  DEPENDS ${LIBS}
+  DEPENDS SDL2 SDL2TTF
 )
 
 ###########
 ## Build ##
 ###########
 
-include_directories(${catkin_INCLUDE_DIRS} ${SDL_INCLUDE_DIR})
+include_directories(${catkin_INCLUDE_DIRS} ${SDL2_INCLUDE_DIRS})
 
 add_executable(keyboard src/main.cpp src/keyboard.cpp)
 
 target_link_libraries(keyboard
-  ${LIBS}
+  ${SDL2_LIBRARIES}
   ${catkin_LIBRARIES}
 )
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-= Description =
+## Description ##
 
 This node uses the SDL2 library to grab keypresses. To do so, it opens a window where input is received. This window needs to be currently focused, otherwise this node will not receive any key presses. 
 
-= Topics =
+## Topics ##
 
-~keydown and ~keyup (keyboard/Key)
+ * ~keydown and ~keyup (keyboard/Key)
 
-= Parameters =
+## Parameters ##
 
-You can optionally use some parameters for customizing window appearance.
+You can optionally use some parameters for customizing window appearance:
 
-~window_width, ~window_height : Window dimensions (defaults to 100x100 pixels)
-~window_caption : Caption to show on windows's frame (defaults to "ROS keyboard input")
-~shown_text : Text to show on the window (defaults to no text at all). This option requires SDL2's TTF extension. 
-~text_font : TrueType font to use; it requires the full path of the .ttf file (defaults to "/usr/share/fonts/truetype/freefont/FreeMono.ttf")
-~font_size : Font size (defaults to 14)
+ * ~window_width, ~window_height : Window dimensions (defaults to 100x100 pixels)
+ * ~window_caption : Caption to show on windows's frame (defaults to "ROS keyboard input")
+ * ~shown_text : Text to show on the window (defaults to no text). This option requires SDL2's TTF extension. 
+ * ~text_font : TrueType font to use; it requires the full path of the .ttf file (defaults to "/usr/share/fonts/truetype/freefont/FreeMono.ttf")
+ * ~font_size : Font size (defaults to 14)

--- a/README.md
+++ b/README.md
@@ -15,3 +15,15 @@ You can optionally use some parameters for customizing window appearance:
  * ~shown_text : Text to show on the window (defaults to no text). This option requires SDL2's TTF extension. 
  * ~text_font : TrueType font to use; it requires the full path of the .ttf file (defaults to "/usr/share/fonts/truetype/freefont/FreeMono.ttf")
  * ~font_size : Font size (defaults to 14)
+
+## Example ##
+```
+  <node name="app_using_keyboard" pkg="keyboard" type="keyboard" output="screen">
+    <param name="window_width" value="320"/>
+    <param name="window_height" value="240"/>
+    <param name="window_caption" value="User commands"/>
+    <param name="shown_text" value="Available commands: &#10;  s:  start &#10;  r:  reset &#10;  q:  quit"/>
+    <param name="text_font" value="/usr/share/fonts/truetype/freefont/FreeMono.ttf"/>
+    <param name="font_size" value="22"/>
+  </node>
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 = Description =
 
-This node uses the SDL library to grab keypresses. To do so, it opens a window where input is received. This window needs to becurrently focused, otherwise this node will not receive any key presses. 
+This node uses the SDL2 library to grab keypresses. To do so, it opens a window where input is received. This window needs to be currently focused, otherwise this node will not receive any key presses. 
 
 = Topics =
 
 ~keydown and ~keyup (keyboard/Key)
+
+= Parameters =
+
+You can optionally use some parameters for customizing window appearance.
+
+~window_width, ~window_height : Window dimensions (defaults to 100x100 pixels)
+~window_caption : Caption to show on windows's frame (defaults to "ROS keyboard input")
+~shown_text : Text to show on the window (defaults to no text at all). This option requires SDL2's TTF extension. 
+~text_font : TrueType font to use; it requires the full path of the .ttf file (defaults to "/usr/share/fonts/truetype/freefont/FreeMono.ttf")
+~font_size : Font size (defaults to 14)

--- a/package.xml
+++ b/package.xml
@@ -11,8 +11,10 @@
 
   <!-- custom dependencies -->
   <build_depend>sdl</build_depend>
+  <build_depend>sdl2-ttf</build_depend>
   <build_depend>ruby</build_depend>
-  <run_depend>sdl</run_depend>
+  <run_depend>sdl2</run_depend>
+  <run_depend>sdl2-ttf</run_depend>
 
   <!-- standard dependencies -->
   <build_depend>std_msgs</build_depend>

--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -51,18 +51,20 @@ keyboard::Keyboard::~Keyboard(void)
 
 void keyboard::Keyboard::render(void)
 {
-  int texW = 0;
-  int texH = 0;
-  SDL_QueryTexture(texture, NULL, NULL, &texW, &texH);
-  SDL_Rect dstrect = { 0, 0, texW, texH };
-  SDL_RenderCopy(renderer, texture, NULL, &dstrect);
+  if (use_ttf)
+  {
+    int texW = 0;
+    int texH = 0;
+    SDL_QueryTexture(texture, NULL, NULL, &texW, &texH);
+    SDL_Rect dstrect = { 0, 0, texW, texH };
+    SDL_RenderCopy(renderer, texture, NULL, &dstrect);
+  }
   SDL_RenderPresent(renderer);
 }
 
 bool keyboard::Keyboard::get_key(bool& new_event, bool& pressed, uint16_t& code, uint16_t& modifiers)
 {
-  if (use_ttf)
-    render();
+  render();
 
   new_event = false;
 

--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -1,43 +1,93 @@
 #include "keyboard.h"
 
-keyboard::Keyboard::Keyboard(void)
+keyboard::Keyboard::Keyboard(int window_width, int window_height, std::string window_caption,
+                             std::string shown_text, std::string text_font, int font_size)
+                  : use_ttf(false), window(NULL), renderer(NULL), surface(NULL), texture(NULL)
 {
-  if (SDL_Init(SDL_INIT_VIDEO) < 0) throw std::runtime_error("Could not init SDL");
-  SDL_EnableKeyRepeat(0, 0);
-  SDL_WM_SetCaption("ROS keyboard input", NULL);
-  window = SDL_SetVideoMode(100, 100, 0, 0);
+  if (SDL_Init(SDL_INIT_VIDEO) < 0)
+    throw std::runtime_error("Could not init SDL");
+  window = SDL_CreateWindow(window_caption.c_str(), SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+                            window_width, window_height, SDL_WINDOW_SHOWN);
+  renderer = SDL_CreateRenderer(window, -1, 0);
+
+  if (! shown_text.empty())
+  {
+    // We have some text to show in the window, so we must use SDL_ttf
+    use_ttf = true;
+
+    // Initialize SDL_ttf library
+    if (TTF_Init() != 0)
+      throw std::runtime_error("Could not init SDL-TTF");
+
+    // Load a font; WARN: at least on Ubuntu it requires the full path of the .ttf file
+    TTF_Font *font = TTF_OpenFont(text_font.c_str(), font_size);
+    if (font == NULL)
+      throw std::runtime_error("Could not open TTF font: " + text_font);
+
+    // Write text to surface; we use SDL2's Blended_Wrapped so line breaks are not ignored
+    SDL_Color text_color = { 255, 255, 255 };
+    surface = TTF_RenderText_Blended_Wrapped(font, shown_text.c_str(), text_color, window_width);
+    if (surface == NULL)
+      throw std::runtime_error("Could not create blended wrapped text surface");
+    texture = SDL_CreateTextureFromSurface(renderer, surface);
+    if (texture == NULL)
+      throw std::runtime_error("Could not create texture from text surface");
+  }
 }
 
 keyboard::Keyboard::~Keyboard(void)
 {
-  SDL_FreeSurface(window);
+  if (use_ttf)
+  {
+    SDL_DestroyTexture(texture);
+    SDL_FreeSurface(surface);
+    TTF_Quit();
+  }
+
+  SDL_DestroyRenderer(renderer);
+  SDL_DestroyWindow(window);
   SDL_Quit();
+}
+
+void keyboard::Keyboard::render(void)
+{
+  int texW = 0;
+  int texH = 0;
+  SDL_QueryTexture(texture, NULL, NULL, &texW, &texH);
+  SDL_Rect dstrect = { 0, 0, texW, texH };
+  SDL_RenderCopy(renderer, texture, NULL, &dstrect);
+  SDL_RenderPresent(renderer);
 }
 
 bool keyboard::Keyboard::get_key(bool& new_event, bool& pressed, uint16_t& code, uint16_t& modifiers)
 {
+  if (use_ttf)
+    render();
+
   new_event = false;
-  
+
   SDL_Event event;
-  if (SDL_PollEvent(&event)) {
-    switch(event.type) {
-      case SDL_KEYUP:
-        pressed = false;
-        code = event.key.keysym.sym;
-        modifiers = event.key.keysym.mod;
-        new_event = true;
-      break;
-      case SDL_KEYDOWN:
-        pressed = true;
-        code = event.key.keysym.sym;
-        modifiers = event.key.keysym.mod;
-        new_event = true;
-      break;
-      case SDL_QUIT:
-        return false;
-      break;
-    }
+  SDL_WaitEvent(&event);
+
+  switch(event.type)
+  {
+    case SDL_KEYUP:
+      pressed = false;
+      code = event.key.keysym.sym;
+      modifiers = event.key.keysym.mod;
+      new_event = true;
+    break;
+    case SDL_KEYDOWN:
+      pressed = true;
+      code = event.key.keysym.sym;
+      modifiers = event.key.keysym.mod;
+      new_event = true;
+    break;
+    case SDL_QUIT:
+      return false;
+    break;
   }
+
   return true;
 }
 

--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -69,25 +69,26 @@ bool keyboard::Keyboard::get_key(bool& new_event, bool& pressed, uint16_t& code,
   new_event = false;
 
   SDL_Event event;
-  SDL_WaitEvent(&event);
-
-  switch(event.type)
+  if (SDL_PollEvent(&event))
   {
-    case SDL_KEYUP:
-      pressed = false;
-      code = event.key.keysym.sym;
-      modifiers = event.key.keysym.mod;
-      new_event = true;
-    break;
-    case SDL_KEYDOWN:
-      pressed = true;
-      code = event.key.keysym.sym;
-      modifiers = event.key.keysym.mod;
-      new_event = true;
-    break;
-    case SDL_QUIT:
-      return false;
-    break;
+    switch(event.type)
+    {
+      case SDL_KEYUP:
+        pressed = false;
+        code = event.key.keysym.sym;
+        modifiers = event.key.keysym.mod;
+        new_event = true;
+      break;
+      case SDL_KEYDOWN:
+        pressed = true;
+        code = event.key.keysym.sym;
+        modifiers = event.key.keysym.mod;
+        new_event = true;
+      break;
+      case SDL_QUIT:
+        return false;
+      break;
+    }
   }
 
   return true;

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -2,19 +2,27 @@
 #define __ROS_KEYBOARD_H__
 
 #include <keyboard/Key.h>
-#include <SDL.h>
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
 
 namespace keyboard {
   class Keyboard {
     public:
-      Keyboard(void);
+      Keyboard(int window_width, int window_height, std::string window_caption,
+               std::string shown_text, std::string text_font, int font_size);
       ~Keyboard(void);
 
+      void render(void);
       bool get_key(bool& new_event, bool& pressed, uint16_t& code, uint16_t& modifiers);
 
     private:
-      SDL_Surface* window;
-  };    
+      bool          use_ttf;
+      SDL_Window*   window;
+      SDL_Renderer* renderer;
+      SDL_Surface*  surface;
+      SDL_Texture*  texture;
+  };
 }
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,8 +47,7 @@ int main(int argc, char** argv)
   catch (std::runtime_error& err)
   {
     ROS_ERROR("ROS keyboard initialization failed: %s", err.what());
-    ros::shutdown();
   }
 
-  ros::waitForShutdown();
+  ros::shutdown();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <ros/ros.h>
-#include <iostream>
+
 #include "keyboard.h"
+
 using namespace std;
 
 int main(int argc, char** argv)
@@ -11,20 +12,43 @@ int main(int argc, char** argv)
   ros::Publisher pub_down = n.advertise<keyboard::Key>("keydown", 10);
   ros::Publisher pub_up = n.advertise<keyboard::Key>("keyup", 10);
 
-  keyboard::Keyboard kbd;
-  ros::Rate r(50);
-  
-  keyboard::Key k;
-  bool pressed, new_event;
-  while (ros::ok() && kbd.get_key(new_event, pressed, k.code, k.modifiers)) {
-    if (new_event) {
-      k.header.stamp = ros::Time::now();
-      if (pressed) pub_down.publish(k);
-      else pub_up.publish(k);
+  // Load optional parameters for customizing window appearance
+  int window_width, window_height, font_size;
+  string window_caption, shown_text, text_font;
+
+  n.param("window_width", window_width, 100);
+  n.param("window_height", window_height, 100);
+  n.param("window_caption", window_caption, string("ROS keyboard input"));
+  n.param("shown_text", shown_text, string(""));
+  n.param("text_font", text_font, string("/usr/share/fonts/truetype/freefont/FreeMono.ttf"));
+  n.param("font_size", font_size, 14);
+
+  try
+  {
+    keyboard::Keyboard kbd(window_width, window_height, window_caption, shown_text, text_font, font_size);
+    ros::Rate r(50);
+
+    keyboard::Key k;
+    bool pressed, new_event;
+    while (ros::ok() && kbd.get_key(new_event, pressed, k.code, k.modifiers))
+    {
+      if (new_event)
+      {
+        k.header.stamp = ros::Time::now();
+        if (pressed)
+          pub_down.publish(k);
+        else
+          pub_up.publish(k);
+      }
+      ros::spinOnce();
+      r.sleep();
     }
-    ros::spinOnce();
-    r.sleep();
   }
-  
+  catch (std::runtime_error& err)
+  {
+    ROS_ERROR("ROS keyboard initialization failed: %s", err.what());
+    ros::shutdown();
+  }
+
   ros::waitForShutdown();
 }


### PR DESCRIPTION
If not used, the application behaves exactly as before. The new parameters are: window_width, window_height, window_caption, shown_text, text_font and font_size.

**SOME HINTS:**
 * shown_text requires SDL2 and SDL2's TTF extension so it doesn't ignore line breaks (as SDL one does). I already added to rosdep repo, so it will be automatically installed with rosdep.
 * text_font requires the full path of the .ttf file, e.g. "/usr/share/fonts/truetype/freefont/FreeMono.ttf"

**TODO:**
 * Would be cool to have a better way for finding fonts, instead of specifiyng the full path of the .ttf file
 * Text color can also be easily customizable.