### PR TITLE
Fix to remove SDL warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0)
 project(keyboard)
 
 find_package(catkin REQUIRED COMPONENTS roscpp std_msgs message_generation)
@@ -24,10 +24,10 @@ generate_messages(
 ###################################
 
 catkin_package(
-  #INCLUDE_DIRS include
-#  LIBRARIES keyboard
+  # INCLUDE_DIRS include
+  # LIBRARIES keyboard
   CATKIN_DEPENDS roscpp std_msgs message_runtime
-  DEPENDS ${LIBS}
+  DEPENDS SDL
 )
 
 ###########


### PR DESCRIPTION
This PR removes the `catkin_package` dependency on the SDL_LIBRARY and instead just puts a dependency on the SDL package. This gets rid of warnings that pop up such as the one [here](https://answers.ros.org/question/247815/annoying-cmake-warning/).